### PR TITLE
Avoid KeyError if a product metadata doesn't have a namespace

### DIFF
--- a/eoreader/products/sar/rcm_product.py
+++ b/eoreader/products/sar/rcm_product.py
@@ -228,7 +228,7 @@ class RcmProduct(SarProduct):
         """Set products type"""
         # Get MTD XML file
         root, nsmap = self.read_mtd()
-        namespace = nsmap[None]
+        namespace = nsmap.get(None, "")
 
         # Open identifier
         prod_type = root.findtext(f".//{namespace}productType")
@@ -263,7 +263,7 @@ class RcmProduct(SarProduct):
         """
         # Get metadata
         root, nsmap = self.read_mtd()
-        namespace = nsmap[None]
+        namespace = nsmap.get(None, "")
 
         # Get sensor mode
         # WARNING: this word may differ from the Enum !!! (no docs available)
@@ -303,7 +303,7 @@ class RcmProduct(SarProduct):
         """
         # Get MTD XML file
         root, nsmap = self.read_mtd()
-        namespace = nsmap[None]
+        namespace = nsmap.get(None, "")
 
         # Open identifier
         acq_date = root.findtext(f".//{namespace}rawDataStartTime")
@@ -426,7 +426,7 @@ class RcmProduct(SarProduct):
         """
         # Get MTD XML file
         root, nsmap = self.read_mtd()
-        namespace = nsmap[None]
+        namespace = nsmap.get(None, "")
 
         # Get the orbit direction
         try:

--- a/eoreader/products/sar/rs2_product.py
+++ b/eoreader/products/sar/rs2_product.py
@@ -379,7 +379,7 @@ class Rs2Product(SarProduct):
 
         # SNAP can process non-complex archive
         root, nsmap = self.read_mtd()
-        namespace = nsmap[None]
+        namespace = nsmap.get(None, "")
 
         # Open identifier
         prod_type = root.findtext(f".//{namespace}productType")
@@ -458,7 +458,7 @@ class Rs2Product(SarProduct):
         """
         # Get metadata
         root, nsmap = self.read_mtd()
-        namespace = nsmap[None]
+        namespace = nsmap.get(None, "")
 
         # Get sensor mode
         # WARNING: this word may differ from the Enum !!! (no docs available)
@@ -499,7 +499,7 @@ class Rs2Product(SarProduct):
         if self.datetime is None:
             # Get MTD XML file
             root, nsmap = self.read_mtd()
-            namespace = nsmap[None]
+            namespace = nsmap.get(None, "")
 
             # Open identifier
             acq_date = root.findtext(f".//{namespace}rawDataStartTime")
@@ -596,7 +596,7 @@ class Rs2Product(SarProduct):
         """
         # Get MTD XML file
         root, nsmap = self.read_mtd()
-        namespace = nsmap[None]
+        namespace = nsmap.get(None, "")
 
         # Get the orbit direction
         try:


### PR DESCRIPTION
For this product: `s3://sertit-rms2/archives/rms/2013/R0009_CHARTE452_Senegal_Inondations_2013/images_crise/Dakar/RISAT-1/133330111.zip`
We have this error
```
Traceback (most recent call last):
  File "E:\JTeulade\repositories\stac\scripts\test.py", line 24, in <module>
    func()
  File "E:\JTeulade\repositories\stac\libs\sertit-utils\sertit\s3.py", line 99, in s3_env_wrapper
    return function(*_args, **_kwargs)
  File "E:\JTeulade\repositories\stac\scripts\test.py", line 16, in func
    prod: Product = Reader().open(tata, remove_tmp=True, method=CheckMethod.MTD)
  File "e:\jteulade\repositories\eoreader\eoreader\reader.py", line 528, in open
    prod = self._open_path(
  File "e:\jteulade\repositories\eoreader\eoreader\reader.py", line 690, in _open_path
    prod = create_product(
  File "e:\jteulade\repositories\eoreader\eoreader\reader.py", line 957, in create_product
    prod = class_(
  File "e:\jteulade\repositories\eoreader\eoreader\products\sar\sar_product.py", line 200, in __init__
    super().__init__(product_path, archive_path, output_path, remove_tmp, **kwargs)
  File "e:\jteulade\repositories\eoreader\eoreader\products\product.py", line 241, in __init__
    self._pre_init(**kwargs)
  File "e:\jteulade\repositories\eoreader\eoreader\products\sar\rs2_product.py", line 382, in _pre_init
    namespace = nsmap[None]
KeyError: None
```
We reuse code from iceye product [here](https://github.com/sertit/eoreader/blob/649de568ec1f7ec58d51a9ae0e796050b4a6c0d2/eoreader/products/sar/iceye_product.py#L204)
