### PR TITLE
FIX: PAZ Product regex & Info url

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,11 @@
 # Release History
 
 ## 0.21.8 (2024-mm-dd)
-- DOC: Added the [PAZ product guide](https://earth.esa.int/eogateway/documents/20142/37627/PAZ-Image-Products-Guide.pdf) to the PAZ Product documentation instead of the TerraSAR-X one 
-- FIX: Fixed PAZ Product Regex to properly indentify PAZ ST products as `PAZProduct` 
 - ENH: Add a new type (`BandsType`) for list of BandType
+- FIX: Fixed PAZ Product Regex to properly indentify PAZ ST products as `PAZProduct` @guillemc23
 - FIX: Remove useless `_norm_diff` function `indices.py`
 - DOC: Update `conf.py` (remove useless hunks and set Sphinx 7 as base)
+- DOC: Added the [PAZ product guide](https://earth.esa.int/eogateway/documents/20142/37627/PAZ-Image-Products-Guide.pdf) to the PAZ Product documentation instead of the TerraSAR-X one @guillemc23
 
 ## 0.21.7 (2024-11-08)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,8 @@
 # Release History
 
 ## 0.21.8 (2024-mm-dd)
-
+- DOC: Added the [PAZ product guide](https://earth.esa.int/eogateway/documents/20142/37627/PAZ-Image-Products-Guide.pdf) to the PAZ Product documentation instead of the TerraSAR-X one 
+- FIX: Fixed PAZ Product Regex to properly indentify PAZ ST products as `PAZProduct` 
 - ENH: Add a new type (`BandsType`) for list of BandType
 - FIX: Remove useless `_norm_diff` function `indices.py`
 - DOC: Update `conf.py` (remove useless hunks and set Sphinx 7 as base)

--- a/eoreader/products/sar/paz_product.py
+++ b/eoreader/products/sar/paz_product.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 """
 PAZ products
-More info `here <https://tandemx-science.dlr.de/pdfs/TX-GS-DD-3302_Basic-Products-Specification-Document_V1.9.pdf>`_.
+More info at https://earth.esa.int/eogateway/documents/20142/37627/PAZ-Image-Products-Guide.pdf.
 """
 from eoreader.products import TsxProduct
 

--- a/eoreader/reader.py
+++ b/eoreader/reader.py
@@ -314,7 +314,7 @@ CONSTELLATION_REGEX = {
     ],
     Constellation.TSX: r"TSX1_SAR__(SSC|MGD|GEC|EEC)_([SR]E|__)___[SH][MCLS]_[SDTQ]_[SD]RA_\d{8}T\d{6}_\d{8}T\d{6}",
     Constellation.TDX: r"TDX1_SAR__(SSC|MGD|GEC|EEC)_([SR]E|__)___[SH][MCLS]_[SDTQ]_[SD]RA_\d{8}T\d{6}_\d{8}T\d{6}",
-    Constellation.PAZ: r"PAZ1_SAR__(SSC|MGD|GEC|EEC)_([SR]E|__)___[SH][MCLS]_[SDTQ]_[SD]RA_\d{8}T\d{6}_\d{8}T\d{6}",
+    Constellation.PAZ: r"PAZ1_SAR__(SSC|MGD|GEC|EEC)_([SR]E|__)___[SH][MCLST]_[SD]_[SD]RA_\d{8}T\d{6}_\d{8}T\d{6}",
     Constellation.RS2: r"RS2_(OK\d+_PK\d+_DK\d+_.{2,}_\d{8}_\d{6}|\d{8}_\d{6}_\d{4}_.{1,5})"
     r"(_(HH|VV|VH|HV)){1,4}_S(LC|GX|GF|CN|CW|CF|CS|SG|PG)(_\d{6}_\d{4}_\d{8}|)",
     Constellation.PLD: r"IMG_PHR1[AB]_(P|MS|PMS|MS-N|MS-X|PMS-N|PMS-X)_\d{3}",


### PR DESCRIPTION
### Description
I was testing EOReader with GEC PAZ Products. I noticed that the Regex to identify PAZ products was failing in some cases. I went through the [PAZ documentation](https://earth.esa.int/eogateway/documents/20142/37627/PAZ-Image-Products-Guide.pdf) and checked the different names its products can have and updated the Regex to match this. I also updated the PAZ Product info url to match this one instead of the TerraSAR one.