### PR TITLE
Fix stack save_as_ int

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Release History
 
 ## 0.21.8 (2024-mm-dd)
+- FIX: Fix stack save_as_int to use updated int values
 - ENH: Add a new type (`BandsType`) for list of BandType
 - FIX: Fixed PAZ Product Regex to properly indentify PAZ ST products as `PAZProduct` @guillemc23
 - FIX: Remove useless `_norm_diff` function `indices.py`

--- a/eoreader/utils.py
+++ b/eoreader/utils.py
@@ -444,7 +444,7 @@ def stack(
                             "Band not in reflectance, keeping them as is (the values will be rounded)"
                         )
                     else:
-                        band_xda = band_xda * scale
+                        band_xds[band] = band_xda * scale
 
             # Fill no data
             band_xds = band_xds.fillna(nodata)


### PR DESCRIPTION
The stack method with the option save_as_int didn't use the scaled values as output. I changed the values to the updated ones.
