### PR TITLE
FIX: Relative paths for GPT graphs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,10 +3,11 @@
 ## 0.21.8 (2024-mm-dd)
 - FIX: Fix stack save_as_int to use updated int values
 - ENH: Add a new type (`BandsType`) for list of BandType
-- FIX: Fixed PAZ Product Regex to properly indentify PAZ ST products as `PAZProduct` @guillemc23
+- FIX: Fixed PAZ Product Regex to properly indentify PAZ ST products as `PAZProduct` - by @guillemc23
+- FIX: Fixed preprocessing graph paths in order to support relative paths in more complex environments or contexts - by @guillemc23
 - FIX: Remove useless `_norm_diff` function `indices.py`
 - DOC: Update `conf.py` (remove useless hunks and set Sphinx 7 as base)
-- DOC: Added the [PAZ product guide](https://earth.esa.int/eogateway/documents/20142/37627/PAZ-Image-Products-Guide.pdf) to the PAZ Product documentation instead of the TerraSAR-X one @guillemc23
+- DOC: Added the [PAZ product guide](https://earth.esa.int/eogateway/documents/20142/37627/PAZ-Image-Products-Guide.pdf) to the PAZ Product documentation instead of the TerraSAR-X one - by @guillemc23
 
 ## 0.21.7 (2024-11-08)
 

--- a/eoreader/products/sar/sar_product.py
+++ b/eoreader/products/sar/sar_product.py
@@ -746,7 +746,7 @@ class SarProduct(Product):
                         f"{spt}_{sat}_preprocess_default.xml"
                     )
                 else:
-                    pp_graph = AnyPath(os.environ[PP_GRAPH]).absolute()
+                    pp_graph = AnyPath(os.environ[PP_GRAPH]).resolve()
                     if not pp_graph.is_file() or not pp_graph.suffix == ".xml":
                         FileNotFoundError(f"{pp_graph} cannot be found.")
 
@@ -847,7 +847,7 @@ class SarProduct(Product):
             if DSPK_GRAPH not in os.environ:
                 dspk_graph = utils.get_data_dir().joinpath("sar_despeckle_default.xml")
             else:
-                dspk_graph = AnyPath(os.environ[DSPK_GRAPH]).absolute()
+                dspk_graph = AnyPath(os.environ[DSPK_GRAPH]).resolve()
                 if not dspk_graph.is_file() or not dspk_graph.suffix == ".xml":
                     FileNotFoundError(f"{dspk_graph} cannot be found.")
 

--- a/eoreader/products/sar/sar_product.py
+++ b/eoreader/products/sar/sar_product.py
@@ -746,7 +746,7 @@ class SarProduct(Product):
                         f"{spt}_{sat}_preprocess_default.xml"
                     )
                 else:
-                    pp_graph = AnyPath(os.environ[PP_GRAPH])
+                    pp_graph = AnyPath(os.environ[PP_GRAPH]).absolute()
                     if not pp_graph.is_file() or not pp_graph.suffix == ".xml":
                         FileNotFoundError(f"{pp_graph} cannot be found.")
 
@@ -847,7 +847,7 @@ class SarProduct(Product):
             if DSPK_GRAPH not in os.environ:
                 dspk_graph = utils.get_data_dir().joinpath("sar_despeckle_default.xml")
             else:
-                dspk_graph = AnyPath(os.environ[DSPK_GRAPH])
+                dspk_graph = AnyPath(os.environ[DSPK_GRAPH]).absolute()
                 if not dspk_graph.is_file() or not dspk_graph.suffix == ".xml":
                     FileNotFoundError(f"{dspk_graph} cannot be found.")
 


### PR DESCRIPTION
I bumped into a problem when using relative paths for my preprocessing and despeckling graphs, since my workdirectory is not the same as the one it will need to be once deployed inside Docker. Using relative imports works  in my code since scripts can find them but these are not good for EOReader since they are not relative to it's execution context.

Adding a `absolute()` on the paths fixes this issue and should work exactly as it did before for other cases.

With a structure like the following, using paths relative to `main.py` should work now, even if running from root, e.g.: `os.environ["EOREADER_PP_GRAPH"] = "./src/graphs/preprocessing.xml"`

```
.
└── root/
    └── src/
        ├── main.py
        └── graphs/
            ├── preprocessing.xml
            └── despeckling.xml
```
