### PR TITLE
FIX: Fixed TSX and TDX Product Regex

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Release History
 
+## 0.22.2 (2025-xx-xx)
+
+- FIX: Fixed TSX and TDX Products Regex to properly identify Staring Spotlight products as `TsxProduct` and `TdxProduct` - by @guillemc23
+
+
 ## 0.22.1 (2025-04-04)
 
 - FIX: Correct the logic behind saving a stack in uint16 in `product.stack`  

--- a/eoreader/reader.py
+++ b/eoreader/reader.py
@@ -319,7 +319,7 @@ CONSTELLATION_REGEX = {
         r"CSG_SSAR\d_(RAW|SCS|DGM|GEC|GTC)_([UBF]|FQLK_B)_\d{4}_(S2[ABC]|D2[RSJ]|OQ[RS]|STR|SC[12]|PPS|QPS)_\d{3}"
         r"_(HH|VV|VH|HV)_[LR][AD]_[DPFR]_\d{14}_\d{14}\_\d_[FC]_\d{2}[NS]_Z\d{2}_[NFB]\d{2}.h5",
     ],
-    Constellation.TSX: r"TSX1_SAR__(SSC|MGD|GEC|EEC)_([SR]E|__)___[SH][MCLS]_[SDTQ]_[SD]RA_\d{8}T\d{6}_\d{8}T\d{6}",
+    Constellation.TSX: r"TSX1_SAR__(SSC|MGD|GEC|EEC)_([SR]E|__)___[SH][MCLST]_[SDTQ]_[SD]RA_\d{8}T\d{6}_\d{8}T\d{6}",
     Constellation.TDX: r"TDX1_SAR__(SSC|MGD|GEC|EEC)_([SR]E|__)___[SH][MCLS]_[SDTQ]_[SD]RA_\d{8}T\d{6}_\d{8}T\d{6}",
     Constellation.PAZ: r"PAZ1_SAR__(SSC|MGD|GEC|EEC)_([SR]E|__)___[SH][MCLST]_[SD]_[SD]RA_\d{8}T\d{6}_\d{8}T\d{6}",
     Constellation.RS2: r"RS2_(OK\d+_PK\d+_DK\d+_.{2,}_\d{8}_\d{6}|\d{8}_\d{6}_\d{4}_.{1,5})"


### PR DESCRIPTION
### Your checklist for this pull request
Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [ ] Check your code additions will fail neither code linting checks nor unit test.

### Description
Fixed both the TerraSAR and TanDEM Product Regex to properly identify Staring Spotlight products. These are properly read once this change is made, simply they were not passing the regex check.