### PR TITLE
Resolve versioned Landsat STAC asset names (fixes #307)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## 0.24.1 (2026-mm-dd)
 
 - FIX: Fix subsetting complex SAR data with a window (cannot be done directly in the ESA SNAP Read Operator)
+- FIX: Fix `KeyError` when loading a Landsat STAC band exposed under a versioned asset name (e.g. `NIR` served as `nir08` on Planetary Computer / Element84) [#307](https://github.com/sertit/eoreader/issues/307)
 
 ## 0.24.0 (2026-05-05)
 

--- a/ci/on_push/test_others.py
+++ b/ci/on_push/test_others.py
@@ -117,6 +117,45 @@ def test_alias():
         to_band(["WRONG_BAND"])
 
 
+def test_landsat_stac_versioned_asset_resolution():
+    """LandsatStacProduct._get_path resolves versioned STAC asset names (#307).
+
+    The Landsat C2 L2 items on Planetary Computer / Element84 expose the NIR
+    band as ``nir08`` rather than the generic ``nir`` that EOREADER maps to,
+    which used to raise ``KeyError: 'nir'``. The closest real asset key must be
+    used instead, without disturbing providers that do expose ``nir``.
+    """
+    from types import SimpleNamespace
+
+    from eoreader.products.optical.landsat_product import LandsatStacProduct
+
+    def fake_product(asset_names):
+        return SimpleNamespace(
+            item=SimpleNamespace(
+                assets={
+                    name: SimpleNamespace(href=f"http://test/{name}.tif")
+                    for name in asset_names
+                }
+            ),
+            bands={NIR: SimpleNamespace(id=5)},
+            sign_url=lambda url: url,
+        )
+
+    # Landsat C2 L2 serves NIR as "nir08": resolve to it instead of raising
+    landsat = fake_product(
+        ["coastal", "blue", "green", "red", "nir08", "swir16", "swir22", "lwir11"]
+    )
+    assert LandsatStacProduct._get_path(landsat, "B5").endswith("nir08.tif")
+
+    # A provider that does expose "nir" must keep using it (no fuzzy detour)
+    generic = fake_product(["blue", "green", "red", "nir", "swir16"])
+    assert LandsatStacProduct._get_path(generic, "B5").endswith("/nir.tif")
+
+    # Nothing close enough still fails explicitly
+    with pytest.raises(FileNotFoundError):
+        LandsatStacProduct._get_path(fake_product(["blue", "red"]), "B5")
+
+
 @s3_env
 @dask_env
 def test_products():

--- a/eoreader/products/optical/landsat_product.py
+++ b/eoreader/products/optical/landsat_product.py
@@ -2048,6 +2048,19 @@ class LandsatStacProduct(StacProduct, LandsatProduct):
                 if band is not None and f"B{band.id}" == band_id
             ][0]
             asset_name = EOREADER_STAC_MAP[band_name].value
+            if asset_name not in self.item.assets:
+                # Some providers expose a band under a versioned STAC name
+                # (e.g. Landsat C2 L2 on Planetary Computer / Element84 serves
+                # the NIR band as "nir08" rather than the generic "nir"), so
+                # fall back to the closest real asset key like the branch below.
+                try:
+                    asset_name = difflib.get_close_matches(
+                        asset_name, self.item.assets.keys(), cutoff=0.5, n=1
+                    )[0]
+                except Exception as exc:
+                    raise FileNotFoundError(
+                        f"Impossible to find an asset in {list(self.item.assets.keys())} close enough to '{asset_name}'"
+                    ) from exc
         else:
             try:
                 asset_name = difflib.get_close_matches(


### PR DESCRIPTION
Closes #307.

### Problem

Loading a band from a Landsat Collection 2 Level-2 STAC item (Planetary Computer / Element84) fails with `KeyError: 'nir'`:

```python
prod = Reader().open("…/landsat-c2-l2/items/LC09_L2SP_203027_20260524_02_T1")
prod.load([NIR])   # KeyError: 'nir'
```

In `LandsatStacProduct._get_path`, the `band_id.startswith("B")` branch maps the band to its generic STAC common name via `EOREADER_STAC_MAP[band_name].value` (`NIR` → `"nir"`) and then indexes `self.item.assets` with it directly. But the Landsat C2 L2 items expose the band under a versioned name — `nir08` — so the lookup raises. Unlike the `else` branch, this branch had no fuzzy fallback against the real asset keys.

### Fix

When the mapped asset name isn't an actual asset key, reuse the same `difflib.get_close_matches(..., cutoff=0.5)` fallback the sibling branch already relies on. It resolves `nir` → `nir08` (ratio 0.75) cleanly, and providers that *do* expose `nir` (e.g. Sentinel-2) keep using it because the guard only triggers on a miss.

### Test

Added `test_landsat_stac_versioned_asset_resolution` (offline, no network): it drives `_get_path` with a Landsat-style asset set (`nir08`) and asserts it resolves there, that a provider exposing `nir` is left untouched, and that a genuinely missing band still raises `FileNotFoundError`. The test fails on `main` (`KeyError: 'nir'`) and passes with the fix.

Thanks @remi-braun for confirming the analysis on the issue.