### PR TITLE
Fix TypeError when passing resampling to load() on Sentinel-2

### DIFF
--- a/ci/on_push/test_others.py
+++ b/ci/on_push/test_others.py
@@ -81,6 +81,19 @@ def test_utils():
     assert utils.get_data_dir() == data_dir
 
 
+def test_prune_resampling_keyword():
+    # Masks are always read with nearest resampling, so a user-supplied
+    # resampling must be pruned before being forwarded to utils.read,
+    # otherwise it collides with the hardcoded value (see issue #313).
+    pruned = utils._prune_keywords(
+        additional_keywords=["resampling"],
+        resampling=Resampling.bilinear,
+        indexes=1,
+    )
+    assert "resampling" not in pruned
+    assert pruned["indexes"] == 1
+
+
 def test_alias():
     # DEM
     assert not is_dem(NDVI)

--- a/eoreader/products/optical/s2_product.py
+++ b/eoreader/products/optical/s2_product.py
@@ -1008,7 +1008,7 @@ class S2Product(OpticalProduct):
                 resampling=Resampling.nearest,
                 as_type=np.uint8,
                 masked=False,
-                **kwargs,
+                **utils._prune_keywords(additional_keywords=["resampling"], **kwargs),
             )
         else:
             if self._processing_baseline < 4.0:
@@ -1157,7 +1157,7 @@ class S2Product(OpticalProduct):
             resampling=Resampling.nearest,
             as_type=np.uint8,
             masked=False,
-            **kwargs,
+            **utils._prune_keywords(additional_keywords=["resampling"], **kwargs),
         )
 
         return mask


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

### Description

Fixes #313.

Loading a Sentinel-2 product with `product.load([..., ALL_CLOUDS], resampling=...)` raised `TypeError: got multiple values for keyword argument 'resampling'`. The two S2 mask readers in `_open_mask`/`_open_mask_gt_4_0` pass `resampling=Resampling.nearest` to `utils.read` while also forwarding the user's `resampling` through `**kwargs`. I pruned `resampling` from those kwargs before the call, mirroring how `landsat_product.py` already handles it (which is why Landsat was unaffected). Masks are categorical, so nearest resampling is kept on purpose.

### Further comments

The added unit test covers the keyword-pruning that prevents the collision, so it runs without satellite data.
