### PR TITLE
derive S2 SAFE L2A cloud bands from SCL

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## 0.24.3 (2026-mm-dd)
 
+- **BREAKING CHANGE**: Derive Sentinel-2 SAFE L2A cloud bands from the Scene Classification Layer (SCL) instead of the
+  cloud probability mask, for consistency with Sentinel-2 E84 products: `SHADOWS` band now available, `RAW_CLOUDS` now
+  returns the SCL class codes [#325](https://github.com/sertit/eoreader/issues/325).
+  Set `EOREADER_S2_CLOUD_SOURCE=CLDPRB` to restore the legacy behavior.
 - FIX: Add platform name for every existing WorldView Legion
 - FIX: Dissolve extents when creating window suffix
 - FIX: Don't try to use `mako` as default colormap if seaborn is not installed

--- a/ci/on_push/test_others.py
+++ b/ci/on_push/test_others.py
@@ -27,8 +27,10 @@ from ci.scripts_utils import (
 )
 from eoreader import utils
 from eoreader.bands import (
+    ALL_CLOUDS,
     BLUE,
     CA,
+    CIRRUS,
     CLOUDS,
     DEM,
     GREEN,
@@ -40,7 +42,9 @@ from eoreader.bands import (
     NARROW_NIR,
     NDVI,
     NIR,
+    RAW_CLOUDS,
     RED,
+    SHADOWS,
     SLOPE,
     SWIR_1,
     SWIR_2,
@@ -61,9 +65,13 @@ from eoreader.bands import (
     is_sat_band,
     to_band,
 )
-from eoreader.env_vars import DEM_PATH, S3_DB_URL_ROOT
+from eoreader.env_vars import DEM_PATH, S2_CLOUD_SOURCE, S3_DB_URL_ROOT
 from eoreader.exceptions import InvalidTypeError
 from eoreader.products import OpticalProduct, SensorType
+from eoreader.products.optical.s2_product import (
+    get_s2_cloud_source,
+    scl_cloud_conditions,
+)
 from eoreader.reader import Constellation
 from eoreader.utils import convert_glob_to_regex
 
@@ -92,6 +100,74 @@ def test_prune_resampling_keyword():
     )
     assert "resampling" not in pruned
     assert pruned["indexes"] == 1
+
+
+def test_scl_cloud_conditions():
+    """Test the SCL class to cloud band mapping (see issue #325)"""
+    # Synthetic SCL array gathering all the existing classes
+    scl_data = np.array([[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]], dtype=np.uint8)
+    scl = xr.DataArray(scl_data, dims=["band", "x"])
+
+    bands = [CLOUDS, SHADOWS, CIRRUS, ALL_CLOUDS, RAW_CLOUDS]
+    conditions, nodata = scl_cloud_conditions(scl, bands)
+
+    # Check the class mapping
+    np.testing.assert_array_equal(conditions[CLOUDS], scl_data == 9)
+    np.testing.assert_array_equal(conditions[SHADOWS], scl_data == 3)
+    np.testing.assert_array_equal(conditions[CIRRUS], scl_data == 10)
+    np.testing.assert_array_equal(conditions[ALL_CLOUDS], np.isin(scl_data, [3, 9, 10]))
+
+    # RAW_CLOUDS gives the raw SCL class codes
+    np.testing.assert_array_equal(conditions[RAW_CLOUDS], scl_data)
+
+    # Nodata condition is the class 0
+    np.testing.assert_array_equal(nodata, scl_data == 0)
+
+    # Classes 2 (cast shadows) and 8 (medium probability) are in no cloud mask
+    for band in [CLOUDS, SHADOWS, CIRRUS, ALL_CLOUDS]:
+        assert not conditions[band][0, 2]
+        assert not conditions[band][0, 8]
+
+    # ALL_CLOUDS is the union of CLOUDS, SHADOWS and CIRRUS
+    union = conditions[CLOUDS] | conditions[SHADOWS] | conditions[CIRRUS]
+    np.testing.assert_array_equal(conditions[ALL_CLOUDS], union)
+
+    # Unknown bands are rejected
+    with pytest.raises(InvalidTypeError):
+        scl_cloud_conditions(scl, [GREEN])
+
+
+def test_s2_cloud_source_env_var():
+    """Test the EOREADER_S2_CLOUD_SOURCE environment variable resolver"""
+    # Unset -> default SCL source, not explicitly set
+    saved_source = os.environ.pop(S2_CLOUD_SOURCE, None)
+    try:
+        source, explicit = get_s2_cloud_source()
+        assert source == "SCL"
+        assert not explicit
+    finally:
+        if saved_source is not None:
+            os.environ[S2_CLOUD_SOURCE] = saved_source
+
+    # Explicitly set -> taken into account (case-insensitive)
+    for value in ["SCL", "scl"]:
+        with tempenv.TemporaryEnvironment({S2_CLOUD_SOURCE: value}):
+            source, explicit = get_s2_cloud_source()
+            assert source == "SCL"
+            assert explicit
+
+    for value in ["CLDPRB", "cldprb"]:
+        with tempenv.TemporaryEnvironment({S2_CLOUD_SOURCE: value}):
+            source, explicit = get_s2_cloud_source()
+            assert source == "CLDPRB"
+            assert explicit
+
+    # Invalid values are rejected
+    with (
+        tempenv.TemporaryEnvironment({S2_CLOUD_SOURCE: "FOO"}),
+        pytest.raises(ValueError),
+    ):
+        get_s2_cloud_source()
 
 
 def test_alias():

--- a/docs/optical.md
+++ b/docs/optical.md
@@ -188,7 +188,7 @@ The only difference with the other bands is that the cloud bands are provided in
 
 | Sensors                       | Cloud files | Clouds Bands                                              |
 |-------------------------------|-------------|-----------------------------------------------------------|
-| Sentinel-2                    | ✅           | `RAW_CLOUDS`, `CLOUDS`, `CIRRUS`, `ALL_CLOUDS`            |
+| Sentinel-2**                  | ✅           | `RAW_CLOUDS`, `CLOUDS`, `SHADOWS`, `CIRRUS`, `ALL_CLOUDS` |
 | Sentinel-2 Theia              | ✅           | `RAW_CLOUDS`, `CLOUDS`, `SHADOWS`, `CIRRUS`, `ALL_CLOUDS` |
 | Vénµs                         | ✅           | `RAW_CLOUDS`, `CLOUDS`, `SHADOWS`, `CIRRUS`, `ALL_CLOUDS` |
 | Sentinel-3 OLCI               | ❌           |                                                           |
@@ -212,6 +212,14 @@ The only difference with the other bands is that the cloud bands are provided in
 | Aleph-1 (Satellogic)*         | ✅           | `RAW_CLOUDS`, `CLOUDS`, `CIRRUS`, `ALL_CLOUDS`            |
 
 * Only true for products generated after 17/11/2025. Before, the cloud bands varied between product types.
+
+** For Sentinel-2, `SHADOWS` is only available for L2A products.
+The cloud bands of L2A products are derived from the Scene Classification Layer (`SCL`),
+with the same class mapping as Sentinel-2 E84 products:
+`CLOUDS` = class 9, `SHADOWS` = class 3, `CIRRUS` = class 10, `ALL_CLOUDS` = classes 3, 9 and 10.
+`RAW_CLOUDS` then gives the raw `SCL` class codes.
+Set `EOREADER_S2_CLOUD_SOURCE=CLDPRB` to restore the legacy behavior based on the cloud probability mask
+(in this case, `SHADOWS` is unavailable and `RAW_CLOUDS` gives the cloud probabilities).
 
 ### DEM bands
 

--- a/eoreader/env_vars.py
+++ b/eoreader/env_vars.py
@@ -117,6 +117,25 @@ Examples:
     >>> os.environ["EOREADER_BAND_RESAMPLING"] = str(Resampling.cubic)
 """
 
+S2_CLOUD_SOURCE = "EOREADER_S2_CLOUD_SOURCE"
+"""
+Environment variable for selecting the cloud source of Sentinel-2 SAFE L2A products.
+
+Available values (case-insensitive):
+
+- :code:`SCL` (default): cloud bands derived from the Scene Classification Layer
+  (:code:`CLOUDS` = class 9, :code:`SHADOWS` = class 3, :code:`CIRRUS` = class 10,
+  :code:`ALL_CLOUDS` = classes 3, 9 and 10, :code:`RAW_CLOUDS` = raw SCL class codes).
+  If the SCL band cannot be found, fall back to the :code:`CLDPRB` source.
+- :code:`CLDPRB`: legacy behavior, cloud bands derived from the cloud probability mask
+  (:code:`CLOUDS` and :code:`ALL_CLOUDS` thresholded at 66%, :code:`RAW_CLOUDS` = cloud probability,
+  :code:`SHADOWS` unavailable).
+
+Only concerns Sentinel-2 SAFE-format L2A products (:code:`S2Product`, :code:`S2StacProduct`).
+No effect on :code:`S2E84Product` or :code:`S2MpcStacProduct` (SCL is their only cloud source),
+nor on L1C products.
+"""
+
 DEFAULT_DRIVER = "EOREADER_DEFAULT_DRIVER"
 """
 Default driver for writing files on disk. 

--- a/eoreader/products/optical/s2_e84_product.py
+++ b/eoreader/products/optical/s2_e84_product.py
@@ -31,18 +31,14 @@ from sertit.types import AnyPathStrType, AnyPathType
 
 from eoreader import DATETIME_FMT, EOREADER_NAME, cache, utils
 from eoreader.bands import (
-    ALL_CLOUDS,
     BLUE,
     CA,
-    CIRRUS,
-    CLOUDS,
     EOREADER_STAC_MAP,
     GREEN,
     NARROW_NIR,
     NIR,
     RAW_CLOUDS,
     RED,
-    SHADOWS,
     SWIR_1,
     SWIR_2,
     SWIR_CIRRUS,
@@ -54,9 +50,10 @@ from eoreader.bands import (
     SpectralBand,
     to_str,
 )
-from eoreader.exceptions import InvalidProductError, InvalidTypeError
+from eoreader.exceptions import InvalidProductError
 from eoreader.products import S2ProductType
 from eoreader.products.optical.optical_product import OpticalProduct, RawUnits
+from eoreader.products.optical.s2_product import scl_cloud_conditions
 from eoreader.products.stac_product import StacProduct
 from eoreader.reader import Constellation
 from eoreader.stac import CENTER_WV, FWHM, GSD, ID, NAME
@@ -667,14 +664,12 @@ class S2E84Product(OpticalProduct):
         """
         Load cloud files as xarrays.
 
-        Values:
-        - 0 : NO_DATA
-        - 3 : CLOUD_SHADOWS
-        - 8 : CLOUD_MEDIUM_PROBABILITY
-        - 9 : CLOUD_HIGH_PROBABILITY
-        - 10 : THIN_CIRRUS
-
-        Only open clouds with high proba.
+        Derived from the Scene Classification Layer (SCL) mask:
+        - CLOUDS: class 9 (cloud high probability)
+        - SHADOWS: class 3 (cloud shadows)
+        - CIRRUS: class 10 (thin cirrus)
+        - ALL_CLOUDS: classes 3, 9 and 10
+        - RAW_CLOUDS: raw SCL class codes
 
         Args:
             bands (list): List of the wanted bands
@@ -690,31 +685,15 @@ class S2E84Product(OpticalProduct):
             # Open Mask
             mask = self.open_mask(pixel_size, size, **kwargs)
 
-            # Don't use load_nodata in order not to load a 2nd time mask
-            nodata_id = self.raw_no_data
-            shadow_id = 3
-            cloud_id = 9
-            cirrus_id = 10
-
-            nodata = np.where(mask == nodata_id, 1, 0).astype(np.uint8)
+            # Derive per-band cloud conditions and nodata from the SCL classes
+            # (don't use load_nodata in order not to load a 2nd time the mask)
+            conditions, nodata = scl_cloud_conditions(mask, bands)
 
             for band in bands:
-                if band == ALL_CLOUDS:
-                    cloud = self._create_mask(
-                        mask, np.isin(mask, [cirrus_id, cloud_id, shadow_id]), nodata
-                    )
-                elif band == SHADOWS:
-                    cloud = self._create_mask(mask, mask == shadow_id, nodata)
-                elif band == CLOUDS:
-                    cloud = self._create_mask(mask, mask == cloud_id, nodata)
-                elif band == CIRRUS:
-                    cloud = self._create_mask(mask, mask == cirrus_id, nodata)
-                elif band == RAW_CLOUDS:
+                if band == RAW_CLOUDS:
                     cloud = mask
                 else:
-                    raise InvalidTypeError(
-                        f"Non existing cloud band for {self.constellation.value} constellations: {band}"
-                    )
+                    cloud = self._create_mask(mask, conditions[band], nodata)
 
                 # Rename
                 band_name = to_str(band)[0]

--- a/eoreader/products/optical/s2_product.py
+++ b/eoreader/products/optical/s2_product.py
@@ -19,6 +19,7 @@ import contextlib
 import difflib
 import json
 import logging
+import os
 from collections import defaultdict, namedtuple
 from datetime import datetime
 from enum import unique
@@ -70,6 +71,7 @@ from eoreader.bands import (
     to_band,
     to_str,
 )
+from eoreader.env_vars import S2_CLOUD_SOURCE
 from eoreader.exceptions import InvalidProductError, InvalidTypeError
 from eoreader.keywords import ASSOCIATED_BANDS
 from eoreader.products import OpticalProduct, StacProduct
@@ -168,6 +170,89 @@ MASK_MAPPING_PB_0400 = {
     S2MaskBandNames.CIRRUS: S2_MSK(mask_fname=S2Jp2Masks.CLASSI, band_number=2),
     S2MaskBandNames.SNOW_ICE: S2_MSK(mask_fname=S2Jp2Masks.CLASSI, band_number=3),
 }
+
+SCL_NODATA = 0
+"""SCL class: no data"""
+
+SCL_CLOUD_SHADOWS = 3
+"""SCL class: cloud shadows"""
+
+SCL_CLOUD_HIGH_PROBABILITY = 9
+"""SCL class: cloud high probability"""
+
+SCL_THIN_CIRRUS = 10
+"""SCL class: thin cirrus"""
+
+SCL_ALL_CLOUD_CLASSES = [
+    SCL_CLOUD_SHADOWS,
+    SCL_CLOUD_HIGH_PROBABILITY,
+    SCL_THIN_CIRRUS,
+]
+"""SCL classes mapped into ALL_CLOUDS"""
+
+
+def get_s2_cloud_source() -> tuple[str, bool]:
+    """
+    Resolve the Sentinel-2 cloud source from the :code:`EOREADER_S2_CLOUD_SOURCE` environment variable.
+
+    Returns:
+        (str, bool): Cloud source (:code:`SCL` or :code:`CLDPRB`),
+        and whether the source was explicitly set by the user
+    """
+    source = os.environ.get(S2_CLOUD_SOURCE)
+    if source is None:
+        # Default cloud source for Sentinel-2 L2A products
+        return "SCL", False
+
+    source = source.upper()
+    if source not in ["SCL", "CLDPRB"]:
+        raise ValueError(
+            f"Invalid value for the {S2_CLOUD_SOURCE} environment variable: '{source}'. "
+            "Should be chosen between 'SCL' and 'CLDPRB'."
+        )
+
+    return source, True
+
+
+def scl_cloud_conditions(scl: xr.DataArray, bands: list) -> tuple[dict, np.ndarray]:
+    """
+    Derive per-band cloud conditions and the nodata condition from a raw SCL array.
+
+    SCL class mapping:
+
+    - :code:`CLOUDS`: class 9 (cloud high probability)
+    - :code:`SHADOWS`: class 3 (cloud shadows)
+    - :code:`CIRRUS`: class 10 (thin cirrus)
+    - :code:`ALL_CLOUDS`: classes 3, 9 and 10
+    - :code:`RAW_CLOUDS`: raw SCL class codes
+
+    Args:
+        scl (xr.DataArray): Raw SCL array
+        bands (list): Wanted cloud bands
+
+    Returns:
+        (dict, np.ndarray): Dictionary of per-band boolean conditions
+        (:code:`RAW_CLOUDS` mapped to the raw SCL array),
+        and nodata condition (1 where SCL == 0, 0 elsewhere)
+    """
+    conditions = {}
+    for band in bands:
+        if band == ALL_CLOUDS:
+            conditions[band] = np.isin(scl, SCL_ALL_CLOUD_CLASSES)
+        elif band == CLOUDS:
+            conditions[band] = scl == SCL_CLOUD_HIGH_PROBABILITY
+        elif band == SHADOWS:
+            conditions[band] = scl == SCL_CLOUD_SHADOWS
+        elif band == CIRRUS:
+            conditions[band] = scl == SCL_THIN_CIRRUS
+        elif band == RAW_CLOUDS:
+            conditions[band] = scl
+        else:
+            raise InvalidTypeError(f"Non existing cloud band for Sentinel-2: {band}")
+
+    nodata = np.where(scl == SCL_NODATA, 1, 0).astype(np.uint8)
+
+    return conditions, nodata
 
 
 class S2Product(OpticalProduct):
@@ -1651,8 +1736,16 @@ class S2Product(OpticalProduct):
     def _has_cloud_band(self, band: BandNames) -> bool:
         """
         Does this product has the specified cloud band?
+
+        L2A products provide all cloud bands (including :code:`SHADOWS`)
+        if the cloud source is the SCL (default, see the :code:`EOREADER_S2_CLOUD_SOURCE` environment variable).
+        With the :code:`CLDPRB` cloud source or at L1C level, the :code:`SHADOWS` band is unavailable.
+
         https://sentinels.copernicus.eu/web/sentinel/technical-guides/sentinel-2-msi/level-1c/cloud-masks
         """
+        if self.product_type == S2ProductType.L2A and get_s2_cloud_source()[0] == "SCL":
+            return True
+
         return band != SHADOWS
 
     def _open_clouds_lt_4_0(
@@ -1866,6 +1959,82 @@ class S2Product(OpticalProduct):
 
         return band_dict
 
+    def _open_clouds_l2a_scl(
+        self,
+        bands: list,
+        pixel_size: float = None,
+        size: list | tuple = None,
+        **kwargs,
+    ) -> dict:
+        """
+        Load L2A cloud bands as xarrays derived from the Scene Classification Layer (SCL),
+        falling back to the cloud probability mask when SCL is missing
+        (unless the SCL cloud source was explicitly requested).
+
+        Args:
+            bands (list): List of the wanted bands
+            pixel_size (int): Band pixel size in meters
+            size (tuple | list): Size of the array (width, height). Not used if pixel_size is provided.
+            kwargs: Additional arguments
+        Returns:
+            dict: Dictionary {band_name, band_xarray}
+        """
+        band_dict = {}
+
+        if bands:
+            _, explicit = get_s2_cloud_source()
+            try:
+                # Resolve the SCL path only to decide the fallback
+                # (works for SAFE on disk, zips and STAC asset lookup)
+                self.get_band_paths([SCL], pixel_size=pixel_size, **kwargs)
+            except (FileNotFoundError, InvalidProductError) as ex:
+                if explicit:
+                    raise InvalidProductError(
+                        f"SCL band not found for {self.path}, although explicitly "
+                        f"requested with the {S2_CLOUD_SOURCE} environment variable"
+                    ) from ex
+
+                LOGGER.warning(
+                    f"SCL band not found for {self.path}, "
+                    f"falling back to the cloud probability mask: {ex}"
+                )
+                return self._open_clouds_l2a(bands, pixel_size, size, **kwargs)
+
+            # Load SCL through the standard cached pipeline
+            # (read + resample once, write the intermediate to the band cache)
+            scl = self._load_s2_l2a_bands(
+                [SCL],
+                pixel_size,
+                size,
+                **utils._prune_keywords(additional_keywords=["resampling"], **kwargs),
+            )[SCL]
+
+            # Cache reads are masked (NaN at class 0): restore the raw class codes
+            scl = scl.fillna(SCL_NODATA).astype(np.uint8)
+
+            # Derive per-band cloud conditions and nodata from the SCL classes
+            conditions, nodata = scl_cloud_conditions(scl, bands)
+
+            for band in bands:
+                if band == RAW_CLOUDS:
+                    cloud = scl
+                else:
+                    cloud = self._create_mask(scl, conditions[band], nodata)
+
+                if len(cloud.shape) == 2:
+                    cloud = cloud.expand_dims(dim="band", axis=0)
+
+                # Rename
+                band_name = to_str(band)[0]
+
+                # Multi bands -> do not change long name
+                if band != RAW_CLOUDS:
+                    cloud.attrs["long_name"] = band_name
+
+                band_dict[band] = cloud.rename(band_name).astype(np.float32)
+
+        return band_dict
+
     def _open_clouds(
         self,
         bands: list,
@@ -1876,8 +2045,11 @@ class S2Product(OpticalProduct):
         """
         Load cloud files as xarrays.
 
-        L2A data (except for CIRRUS):
-        Read S2 MSK_CLDPRB_20m .JP2 file
+        L2A data:
+        By default, cloud bands are derived from the Scene Classification Layer (SCL),
+        with the same class mapping as Sentinel-2 E84 products.
+        Set the :code:`EOREADER_S2_CLOUD_SOURCE` environment variable to :code:`CLDPRB`
+        to read instead the S2 MSK_CLDPRB_20m .JP2 file (legacy behavior).
 
         L1C data with baseline > 4.0
         Read S2 cloud mask .JP2 files (both valid for L2A and L1C products).
@@ -1896,7 +2068,11 @@ class S2Product(OpticalProduct):
             dict: Dictionary {band_name, band_xarray}
         """
         if self.product_type == S2ProductType.L2A:
-            clouds = self._open_clouds_l2a(bands, pixel_size, size, **kwargs)
+            cloud_source, _ = get_s2_cloud_source()
+            if cloud_source == "SCL":
+                clouds = self._open_clouds_l2a_scl(bands, pixel_size, size, **kwargs)
+            else:
+                clouds = self._open_clouds_l2a(bands, pixel_size, size, **kwargs)
         else:
             if self._processing_baseline < 4.0:
                 clouds = self._open_clouds_lt_4_0(bands, pixel_size, size, **kwargs)


### PR DESCRIPTION
Hi,

This PR addresses #325 by making Sentinel-2 SAFE L2A products derive their cloud bands from the Scene Classification Layer (SCL), just like S2E84Product already does.

## Why
 the current L2A cloud mask is based on MSK_CLDPRB_20m.jp2 (>66%), which gives coarser results than the SCL and does not expose SHADOWS. Switching to SCL makes L2A consistent with E84 and gives cleaner CLOUDS, CIRRUS, and SHADOWS masks.

## What changed
- L2A SAFE products now use SCL by default (CLOUDS = class 9, SHADOWS = class 3, CIRRUS = class 10, ALL_CLOUDS = 3/9/10, RAW_CLOUDS = raw class codes).
- SHADOWS is now available for L2A.
- RAW_CLOUDS semantics change to SCL class codes (0-11).
- Legacy behavior is preserved via EOREADER_S2_CLOUD_SOURCE=CLDPRB.
- SCL mapping logic shared between S2Product and S2E84Product.
- Fallback to CLDPRB when SCL is missing (unless explicitly requested).

Would this be OK for you ?
Happy to adjust anything if needed!